### PR TITLE
Add GitHub Pages workflow and static site files

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>未来感个人网站 | 你的名字</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="ambient-glow"></div>
+  <header class="site-header">
+    <nav class="nav">
+      <div class="logo">NOVA//ME</div>
+      <div class="nav-links">
+        <a href="#about">关于</a>
+        <a href="#projects">作品</a>
+        <a href="#stack">技能</a>
+        <a href="#contact">联系</a>
+      </div>
+      <button class="cta">预约合作</button>
+    </nav>
+    <section class="hero">
+      <div class="hero-content">
+        <p class="eyebrow">未来感数字档案 / 2035</p>
+        <h1>你好，我是<span>你的名字</span>，
+          <br />专注于打造沉浸式数字体验。
+        </h1>
+        <p class="lead">
+          在视觉与科技的交汇处，用策略、设计与工程能力实现品牌的未来表达。
+        </p>
+        <div class="hero-actions">
+          <button class="primary">查看作品集</button>
+          <button class="ghost">下载简历</button>
+        </div>
+        <div class="hero-stats">
+          <div>
+            <strong>08</strong>
+            <span>年经验</span>
+          </div>
+          <div>
+            <strong>42</strong>
+            <span>项目交付</span>
+          </div>
+          <div>
+            <strong>16</strong>
+            <span>全球合作</span>
+          </div>
+        </div>
+      </div>
+      <div class="hero-card">
+        <div class="pulse"></div>
+        <div class="card-header">
+          <span>状态</span>
+          <span class="status">可预约</span>
+        </div>
+        <h3>数字化身 / Profile</h3>
+        <ul>
+          <li>城市：上海</li>
+          <li>专注：品牌体验 / 互动设计</li>
+          <li>目标：AI + 设计融合</li>
+        </ul>
+        <div class="card-footer">
+          <span>签名</span>
+          <span class="signature">//未来由此启航</span>
+        </div>
+      </div>
+    </section>
+  </header>
+
+  <main>
+    <section id="about" class="section glass">
+      <div>
+        <h2>关于我</h2>
+        <p>
+          我是一名跨学科创意人，擅长将前沿技术与视觉叙事融合，打造具有未来感与商业价值的体验。
+          我相信设计不仅是美学，更是连接人与技术的桥梁。
+        </p>
+      </div>
+      <div class="metrics">
+        <div>
+          <h4>战略</h4>
+          <p>品牌定位、体验策略、用户洞察</p>
+        </div>
+        <div>
+          <h4>设计</h4>
+          <p>视觉系统、动效设计、3D 想象</p>
+        </div>
+        <div>
+          <h4>工程</h4>
+          <p>WebGL、前端工程、原型开发</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="projects" class="section">
+      <div class="section-head">
+        <h2>精选作品</h2>
+        <p>从概念到落地，探索未来体验的可能性。</p>
+      </div>
+      <div class="project-grid">
+        <article class="project-card">
+          <h3>星际品牌体验</h3>
+          <p>为全球科技品牌打造沉浸式发布会体验。</p>
+          <span>2024 / Strategy + Design</span>
+        </article>
+        <article class="project-card">
+          <h3>城市数字孪生</h3>
+          <p>构建城市级交互平台，连接公共服务与市民。</p>
+          <span>2023 / UX + Front-end</span>
+        </article>
+        <article class="project-card">
+          <h3>AI 未来零售</h3>
+          <p>融合 AI 与零售场景，打造智能化消费旅程。</p>
+          <span>2022 / Product + UX</span>
+        </article>
+      </div>
+    </section>
+
+    <section id="stack" class="section glass">
+      <div class="section-head">
+        <h2>能力矩阵</h2>
+        <p>聚焦未来体验的技能组合。</p>
+      </div>
+      <div class="stack-list">
+        <div>设计系统</div>
+        <div>品牌视觉</div>
+        <div>互动原型</div>
+        <div>沉浸式体验</div>
+        <div>AI 创意流程</div>
+        <div>前端工程</div>
+      </div>
+    </section>
+
+    <section id="contact" class="section contact">
+      <div>
+        <h2>连接未来</h2>
+        <p>欢迎讨论合作、创新与未来构想。</p>
+      </div>
+      <form class="contact-form">
+        <input type="text" placeholder="你的名字" />
+        <input type="email" placeholder="电子邮箱" />
+        <textarea rows="4" placeholder="告诉我你的想法"></textarea>
+        <button type="submit">发送</button>
+      </form>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <span>© 2035 你的名字. Future ready.</span>
+    <div>
+      <a href="#">Behance</a>
+      <a href="#">LinkedIn</a>
+      <a href="#">Dribbble</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,362 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap');
+
+:root {
+  color-scheme: dark;
+  --bg: #05050b;
+  --surface: rgba(16, 18, 34, 0.7);
+  --primary: #7cf9ff;
+  --accent: #8b5cf6;
+  --text: #e6ecff;
+  --muted: #a0a7c5;
+  --border: rgba(124, 249, 255, 0.2);
+  --glow: 0 0 30px rgba(124, 249, 255, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Space Grotesk', sans-serif;
+  background: radial-gradient(circle at 20% 20%, #1b1f3a, transparent 55%),
+    radial-gradient(circle at 80% 10%, #311a52, transparent 45%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  line-height: 1.6;
+  overflow-x: hidden;
+}
+
+.ambient-glow {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 50% 50%, rgba(124, 249, 255, 0.08), transparent 60%),
+    radial-gradient(circle at 70% 70%, rgba(139, 92, 246, 0.1), transparent 50%);
+  pointer-events: none;
+  z-index: -1;
+}
+
+.site-header {
+  padding: 32px 8vw 80px;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.logo {
+  font-weight: 700;
+  letter-spacing: 3px;
+  color: var(--primary);
+}
+
+.nav-links {
+  display: flex;
+  gap: 20px;
+  font-size: 0.95rem;
+}
+
+.nav-links a,
+.site-footer a {
+  color: var(--muted);
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+.nav-links a:hover,
+.site-footer a:hover {
+  color: var(--primary);
+}
+
+.cta {
+  background: linear-gradient(120deg, var(--primary), var(--accent));
+  border: none;
+  color: #04040d;
+  padding: 10px 20px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--glow);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 40px;
+  margin-top: 70px;
+  align-items: center;
+}
+
+.eyebrow {
+  color: var(--primary);
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-size: 0.75rem;
+  margin-bottom: 12px;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 4vw, 3.6rem);
+  line-height: 1.1;
+}
+
+.hero h1 span {
+  color: var(--primary);
+}
+
+.lead {
+  color: var(--muted);
+  margin-top: 20px;
+  max-width: 520px;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 16px;
+  margin: 28px 0 36px;
+}
+
+.primary,
+.ghost {
+  padding: 12px 22px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary {
+  background: var(--primary);
+  color: #03030a;
+  box-shadow: var(--glow);
+}
+
+.ghost {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.primary:hover,
+.ghost:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 30px rgba(124, 249, 255, 0.2);
+}
+
+.hero-stats {
+  display: flex;
+  gap: 32px;
+}
+
+.hero-stats strong {
+  font-size: 1.5rem;
+  display: block;
+}
+
+.hero-card {
+  background: var(--surface);
+  border: 1px solid rgba(124, 249, 255, 0.1);
+  padding: 28px;
+  border-radius: 24px;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 30px 60px rgba(7, 10, 30, 0.6);
+}
+
+.hero-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(124, 249, 255, 0.08), transparent 60%);
+  pointer-events: none;
+}
+
+.pulse {
+  position: absolute;
+  inset: 20% 10% auto;
+  height: 60px;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(124, 249, 255, 0.4), transparent 60%);
+  filter: blur(6px);
+  animation: pulse 4s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(0.95);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+}
+
+.card-header,
+.card-footer {
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.status {
+  color: var(--primary);
+}
+
+.hero-card h3 {
+  margin: 16px 0 12px;
+  font-size: 1.2rem;
+}
+
+.hero-card ul {
+  list-style: none;
+  color: var(--muted);
+}
+
+.hero-card li {
+  margin-bottom: 8px;
+}
+
+.signature {
+  color: var(--primary);
+}
+
+main {
+  padding: 0 8vw 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 70px;
+}
+
+.section {
+  display: grid;
+  gap: 24px;
+}
+
+.section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.section h2 {
+  font-size: 2rem;
+}
+
+.section p {
+  color: var(--muted);
+}
+
+.glass {
+  background: var(--surface);
+  border: 1px solid rgba(124, 249, 255, 0.08);
+  border-radius: 24px;
+  padding: 32px;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 20px;
+}
+
+.project-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+}
+
+.project-card {
+  background: rgba(15, 18, 32, 0.8);
+  border-radius: 20px;
+  padding: 24px;
+  border: 1px solid rgba(124, 249, 255, 0.08);
+  transition: transform 0.3s ease, border 0.3s ease;
+}
+
+.project-card:hover {
+  transform: translateY(-8px);
+  border-color: rgba(124, 249, 255, 0.4);
+}
+
+.project-card span {
+  display: block;
+  color: var(--muted);
+  margin-top: 12px;
+  font-size: 0.85rem;
+}
+
+.stack-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.stack-list div {
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: rgba(124, 249, 255, 0.1);
+  border: 1px solid rgba(124, 249, 255, 0.2);
+  color: var(--primary);
+}
+
+.contact {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 32px;
+  align-items: center;
+}
+
+.contact-form {
+  display: grid;
+  gap: 16px;
+}
+
+.contact-form input,
+.contact-form textarea {
+  background: rgba(7, 8, 18, 0.7);
+  border: 1px solid rgba(124, 249, 255, 0.2);
+  border-radius: 16px;
+  padding: 12px 16px;
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.contact-form button {
+  background: linear-gradient(120deg, var(--primary), var(--accent));
+  border: none;
+  padding: 12px;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.site-footer {
+  padding: 32px 8vw 40px;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 20px;
+  color: var(--muted);
+}
+
+@media (max-width: 768px) {
+  .nav {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero-actions,
+  .hero-stats {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a single-page futuristic personal website as a starting template and include styles for a dark glassmorphism/neon look.
- Enable automatic publishing and a live preview by configuring a GitHub Actions workflow to deploy the site to GitHub Pages.
- Allow manual dispatch and deployments on pushes to `main`/`master` so the preview can be updated easily.

### Description
- Add `index.html` implementing a single-page layout (hero, about, projects, skills, contact) and copy in localizable Chinese text and structure.
- Add `styles.css` that imports `Space Grotesk`, defines dark theme variables, and implements glassmorphism/neon visuals, responsive layout, and simple animations.
- Add `.github/workflows/pages.yml` which triggers on push to `main`/`master` and `workflow_dispatch`, grants `pages: write` and `id-token: write` permissions, and uses `actions/configure-pages@v5`, `actions/upload-pages-artifact@v3` (with `path: .`), and `actions/deploy-pages@v4` to publish the site.

### Testing
- Verified repository status with `git -C /workspace/stunning-journey status --short` and staged the workflow file with `git -C /workspace/stunning-journey add .github/workflows/pages.yml` before committing.
- Created the commit with `git -C /workspace/stunning-journey commit -m "Add GitHub Pages deployment workflow"`, and the commit succeeded.
- No CI/workflow runs or automated site renderings were executed in this environment, so the GitHub Actions deployment has not yet been validated (it must run after pushing to the remote repository and enabling Pages in Settings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979b8774a80832aa6c262635c7528c7)