### PR TITLE
Add: writing folder assets + CLI (md relative paths)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ dist/
 # dependencies
 node_modules/
 
+# generated writing assets (copied from src/content/writing/**)
+public/writing/
+
 # logs
 npm-debug.log*
 yarn-debug.log*

--- a/README.md
+++ b/README.md
@@ -29,6 +29,43 @@ npm run preview
 - Tags：`/tags`
 - Now：`/now`
 
+### 文章与资源同目录（推荐）
+
+每篇文章一个目录：
+
+```text
+src/content/writing/
+  <slug>/
+    index.md
+    cover.jpg
+    arch.png
+```
+
+在 `index.md` 中直接用相对路径引用：
+
+```md
+![cover](cover.jpg)
+![arch](arch.png)
+```
+
+构建时会自动：
+- 将资源复制到 `public/writing/<slug>/...`
+- 将 Markdown 中的相对图片链接改写为 `/writing/<slug>/...`（通过 remark 插件，不改你的源文件）
+
+### 命令行工具
+
+```bash
+# 新建文章目录（index.md + 基础 frontmatter）
+npm run new:post
+npm run new:post -- --title "标题" --slug my-post --tags "ai,tooling" --date 2026-02-02
+
+# 同步文章资源到 public（构建/开发前可单独跑）
+npm run sync:assets
+
+# 开发：启动 dev server + 监听 writing 目录变化自动同步资源
+npm run dev:watch
+```
+
 ---
 
 ## TODO（路线图）

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,11 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import { remarkRewriteLocalAssets } from './scripts/remark-rewrite-local-assets.mjs';
 
 // https://astro.build/config
 export default defineConfig({
   site: 'https://jingkaitang.github.io',
+  markdown: {
+    remarkPlugins: [remarkRewriteLocalAssets],
+  },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/rss": "^4.0.15",
         "astro": "^5.17.1",
+        "chokidar": "^3.6.0",
         "pagefind": "^1.3.0"
       }
     },
@@ -1861,6 +1862,18 @@
       "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
       "license": "MIT"
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/boolbase/-/boolbase-1.0.0.tgz",
@@ -1887,6 +1900,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/camelcase": {
@@ -1954,18 +1979,27 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmmirror.com/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^5.0.0"
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
       },
       "engines": {
-        "node": ">= 20.19.0"
+        "node": ">= 8.10.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/ci-info": {
@@ -2459,6 +2493,18 @@
         }
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmmirror.com/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/flattie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmmirror.com/flattie/-/flattie-1.1.1.tgz",
@@ -2520,6 +2566,18 @@
       "resolved": "https://registry.npmmirror.com/github-slugger/-/github-slugger-2.0.0.tgz",
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/h3": {
       "version": "1.15.5",
@@ -2756,6 +2814,18 @@
         "url": "https://github.com/sponsors/brc-dd"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/is-docker/-/is-docker-3.0.0.tgz",
@@ -2771,6 +2841,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2778,6 +2857,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-inside-container": {
@@ -2796,6 +2887,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-plain-obj": {
@@ -3998,16 +4098,27 @@
       "license": "MIT"
     },
     "node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmmirror.com/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 20.19.0"
+        "node": ">=8.6"
       },
       "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/regex": {
@@ -4514,6 +4625,18 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmmirror.com/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -4852,6 +4975,34 @@
         "uploadthing": {
           "optional": true
         }
+      }
+    },
+    "node_modules/unstorage/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/unstorage/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -4,13 +4,17 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build && pagefind --site dist",
+    "dev:watch": "node scripts/dev-watch.mjs",
+    "sync:assets": "node scripts/sync-writing-assets.mjs",
+    "new:post": "node scripts/new-post.mjs",
+    "build": "npm run sync:assets && astro build && pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.15",
     "astro": "^5.17.1",
+    "chokidar": "^3.6.0",
     "pagefind": "^1.3.0"
   }
 }

--- a/scripts/dev-watch.mjs
+++ b/scripts/dev-watch.mjs
@@ -1,0 +1,34 @@
+import { spawn } from 'node:child_process';
+import chokidar from 'chokidar';
+
+function run(cmd, args, opts = {}) {
+  return spawn(cmd, args, { stdio: 'inherit', shell: false, ...opts });
+}
+
+// Start Astro dev server
+const dev = run('npm', ['run', 'dev'], { env: process.env });
+
+const watcher = chokidar.watch(['src/content/writing/**/*'], {
+  ignoreInitial: true,
+});
+
+let timer = null;
+function scheduleSync() {
+  clearTimeout(timer);
+  timer = setTimeout(() => {
+    run('npm', ['run', 'sync:assets'], { env: process.env });
+  }, 150);
+}
+
+watcher
+  .on('add', scheduleSync)
+  .on('change', scheduleSync)
+  .on('unlink', scheduleSync)
+  .on('addDir', scheduleSync)
+  .on('unlinkDir', scheduleSync);
+
+process.on('SIGINT', () => {
+  watcher.close().catch(() => {});
+  dev.kill('SIGINT');
+  process.exit(0);
+});

--- a/scripts/new-post.mjs
+++ b/scripts/new-post.mjs
@@ -1,0 +1,123 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+
+const ROOT = process.cwd();
+const WRITING_DIR = path.join(ROOT, 'src', 'content', 'writing');
+
+function slugify(s) {
+  return String(s)
+    .trim()
+    .toLowerCase()
+    .replace(/['"`]/g, '')
+    .replace(/[^a-z0-9\u4e00-\u9fa5]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/--+/g, '-');
+}
+
+function todayISO() {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const key = a.slice(2);
+    const val = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[++i] : 'true';
+    out[key] = val;
+  }
+  return out;
+}
+
+async function ensureDir(dir) {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+async function exists(p) {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  const rl = readline.createInterface({ input, output });
+
+  const title = args.title && args.title !== 'true' ? args.title : await rl.question('Title: ');
+  const slugRaw = args.slug && args.slug !== 'true' ? args.slug : await rl.question('Slug (empty = auto): ');
+  const tagsRaw = args.tags && args.tags !== 'true' ? args.tags : await rl.question('Tags (comma-separated, optional): ');
+  const dateRaw = args.date && args.date !== 'true' ? args.date : await rl.question(`Date (YYYY-MM-DD, default ${todayISO()}): `);
+
+  await rl.close();
+
+  const pubDate = (dateRaw || '').trim() || todayISO();
+  const slug = (slugRaw || '').trim() ? slugify(slugRaw) : slugify(title);
+
+  if (!slug) {
+    throw new Error('Slug is empty. Provide --slug or a non-empty title.');
+  }
+
+  const tags = (tagsRaw || '')
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
+
+  const postDir = path.join(WRITING_DIR, slug);
+  const mdPath = path.join(postDir, 'index.md');
+
+  if (await exists(mdPath)) {
+    throw new Error(`Post already exists: ${path.relative(ROOT, mdPath)}`);
+  }
+
+  await ensureDir(postDir);
+
+  const fm = [
+    '---',
+    `title: ${JSON.stringify(title)}`,
+    `description: ${JSON.stringify('')}`,
+    `pubDate: ${JSON.stringify(pubDate)}`,
+    `tags: [${tags.map((t) => JSON.stringify(t)).join(', ')}]`,
+    'draft: true',
+    '---',
+    '',
+  ].join('\n');
+
+  const body = [
+    '# ' + title,
+    '',
+    '（先写结论/观点，然后再补充论证与步骤。写作结构可随时演进。）',
+    '',
+    '![cover](cover.jpg)',
+    '',
+    '## 结论',
+    '',
+    'TODO',
+    '',
+    '## 过程 / 论证',
+    '',
+    'TODO',
+    '',
+    '## 参考',
+    '',
+    '- TODO',
+    '',
+  ].join('\n');
+
+  await fs.writeFile(mdPath, fm + body, 'utf8');
+
+  console.log(`Created: ${path.relative(ROOT, mdPath)}`);
+  console.log(`Assets dir (put images here): ${path.relative(ROOT, postDir)}/`);
+}
+
+await main();

--- a/scripts/remark-rewrite-local-assets.mjs
+++ b/scripts/remark-rewrite-local-assets.mjs
@@ -1,0 +1,54 @@
+import path from 'node:path';
+
+function normalizeSlugFromFile(filePath) {
+  // Expect: .../src/content/writing/<slug>/index.md
+  const parts = filePath.split(path.sep);
+  const writingIdx = parts.lastIndexOf('writing');
+  if (writingIdx >= 0 && parts[parts.length - 1] === 'index.md' && parts.length >= writingIdx + 3) {
+    return parts[writingIdx + 1];
+  }
+
+  // Fallback: .../src/content/writing/<slug>.md
+  const base = path.basename(filePath, path.extname(filePath));
+  if (base) return base;
+
+  return null;
+}
+
+function isRelativeUrl(url) {
+  return typeof url === 'string' && url.length > 0 && !url.startsWith('/') && !url.startsWith('http://') && !url.startsWith('https://') && !url.startsWith('#');
+}
+
+export function remarkRewriteLocalAssets() {
+  return function transformer(tree, file) {
+    const filePath = file?.path ? String(file.path) : '';
+    const slug = filePath ? normalizeSlugFromFile(filePath) : null;
+    if (!slug) return;
+
+    /** @type {import('unist').Node[]} */
+    const stack = [tree];
+
+    while (stack.length) {
+      const node = stack.pop();
+      if (!node || typeof node !== 'object') continue;
+
+      // rewrite markdown images: ![alt](url)
+      if (node.type === 'image' && isRelativeUrl(node.url)) {
+        node.url = `/writing/${slug}/${node.url}`;
+      }
+
+      // rewrite links that look like local assets too
+      if (node.type === 'link' && isRelativeUrl(node.url)) {
+        // Don't rewrite links to other pages like ../something (we only rewrite same-folder files)
+        if (!node.url.startsWith('../') && !node.url.startsWith('./')) {
+          node.url = `/writing/${slug}/${node.url}`;
+        }
+      }
+
+      const children = node.children;
+      if (Array.isArray(children)) {
+        for (const c of children) stack.push(c);
+      }
+    }
+  };
+}

--- a/scripts/sync-writing-assets.mjs
+++ b/scripts/sync-writing-assets.mjs
@@ -1,0 +1,88 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const SRC_WRITING_DIR = path.join(ROOT, 'src', 'content', 'writing');
+const PUBLIC_WRITING_DIR = path.join(ROOT, 'public', 'writing');
+
+const ASSET_EXTS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg', '.mp4']);
+
+async function exists(p) {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureDir(dir) {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+async function* walk(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      yield* walk(p);
+    } else {
+      yield p;
+    }
+  }
+}
+
+function slugFromIndexMd(indexMdPath) {
+  // src/content/writing/<slug>/index.md => <slug>
+  const rel = path.relative(SRC_WRITING_DIR, indexMdPath);
+  const parts = rel.split(path.sep);
+  if (parts.length >= 2 && parts[parts.length - 1] === 'index.md') {
+    return parts[parts.length - 2];
+  }
+  // fallback: src/content/writing/<slug>.md
+  return path.basename(indexMdPath, path.extname(indexMdPath));
+}
+
+async function syncOnePostDir(postDir) {
+  const indexMd = path.join(postDir, 'index.md');
+  if (!(await exists(indexMd))) return;
+
+  const slug = slugFromIndexMd(indexMd);
+  const outDir = path.join(PUBLIC_WRITING_DIR, slug);
+  await ensureDir(outDir);
+
+  const entries = await fs.readdir(postDir, { withFileTypes: true });
+  for (const e of entries) {
+    if (!e.isFile()) continue;
+    if (e.name === 'index.md') continue;
+
+    const ext = path.extname(e.name).toLowerCase();
+    if (!ASSET_EXTS.has(ext)) continue;
+
+    const src = path.join(postDir, e.name);
+    const dst = path.join(outDir, e.name);
+    await fs.copyFile(src, dst);
+  }
+}
+
+async function main() {
+  if (!(await exists(SRC_WRITING_DIR))) {
+    console.warn(`[sync:assets] No writing dir: ${SRC_WRITING_DIR}`);
+    return;
+  }
+
+  // Only treat directories with index.md as posts.
+  const top = await fs.readdir(SRC_WRITING_DIR, { withFileTypes: true });
+  const postDirs = top.filter((e) => e.isDirectory()).map((e) => path.join(SRC_WRITING_DIR, e.name));
+
+  for (const d of postDirs) {
+    await syncOnePostDir(d);
+  }
+
+  // Also support legacy flat files: src/content/writing/*.md + src/content/writing/<slug>/* assets not supported.
+  // (No-op here on purpose.)
+
+  console.log(`[sync:assets] Synced assets for ${postDirs.length} post folders -> public/writing/`);
+}
+
+await main();

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -33,7 +33,7 @@ const posts = (await getCollection('writing'))
       {posts.map((post) => (
         <article class="project-card" style="transform:none;">
           <h3 style="margin-bottom: 6px;">
-            <a href={`/writing/${post.slug}/`} style="color: var(--text); text-decoration:none;">
+            <a href={`/writing/${post.slug.replace(/\/index$/, '')}/`} style="color: var(--text); text-decoration:none;">
               {post.data.title}
             </a>
           </h3>

--- a/src/pages/writing/[slug].astro
+++ b/src/pages/writing/[slug].astro
@@ -6,7 +6,10 @@ export async function getStaticPaths() {
   const posts = await getCollection('writing');
   return posts
     .filter((p) => !p.data.draft)
-    .map((p) => ({ params: { slug: p.slug }, props: { post: p } }));
+    .map((p) => ({
+      params: { slug: p.slug.replace(/\/index$/, '') },
+      props: { post: p },
+    }));
 }
 
 const { post } = Astro.props;
@@ -15,7 +18,11 @@ const { Content, headings } = await render(post);
 const toc = (headings ?? []).filter((h) => h.depth >= 2 && h.depth <= 3);
 ---
 
-<BaseLayout title={`${post.data.title} | 唐靖凯`} description={post.data.description}>
+<BaseLayout
+  title={`${post.data.title} | 唐靖凯`}
+  description={post.data.description}
+  canonical={`/writing/${post.slug.replace(/\/index$/, '')}/`}
+>
   <section class="section glass" style="max-width: 980px;">
     <div class="post-shell">
       <article class="post">

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -18,7 +18,7 @@ const posts = (await getCollection('writing'))
       {posts.map((post) => (
         <article class="project-card" style="transform:none;">
           <h3 style="margin-bottom: 6px;">
-            <a href={`/writing/${post.slug}/`} style="color: var(--text); text-decoration:none;">
+            <a href={`/writing/${post.slug.replace(/\/index$/, '')}/`} style="color: var(--text); text-decoration:none;">
               {post.data.title}
             </a>
           </h3>


### PR DESCRIPTION
## 背景

希望文章与资源文件放同一个目录，Markdown 里用相对路径引用（如 `![cover](cover.jpg)`），但线上仍能用 `/writing/<slug>/...` 的静态路径稳定访问。

## 这次做了什么

- 新增写作目录规范：`src/content/writing/<slug>/index.md` + 同目录图片/资源
- 构建前自动同步资源：复制到 `public/writing/<slug>/...`
- 构建时自动改写 Markdown 中的相对图片链接为 `/writing/<slug>/...`（remark 插件，不改源文件）
- 新增 CLI：
  - `npm run new:post`（新建文章目录/文件）
  - `npm run sync:assets`（同步资源）
  - `npm run dev:watch`（dev + 监听自动同步）
- 修正 writing 列表/标签页/文章页对 `.../index` slug 的兼容，保证 URL 仍是 `/writing/<slug>/`

## 验证

- 本地 `npm run build` 通过
- 测试文章中 `![cover](cover.jpg)` 输出 HTML 为 `src="/writing/<slug>/cover.jpg"`
