### PR TITLE
Refactor: Now entries as writing posts tagged now

### DIFF
--- a/src/content/writing/now-2026-01-31/index.md
+++ b/src/content/writing/now-2026-01-31/index.md
@@ -1,0 +1,19 @@
+---
+title: "Now: 周末试用 OpenClaw 大龙虾"
+description: "拿出老笔记本重装 CachyOS，部署大龙虾，配置 channels/models，并创建本项目。"
+pubDate: 2026-01-31
+tags: ["now", "openclaw", "setup"]
+draft: false
+---
+
+一句话：周末试用 OpenClaw「大龙虾」：把老笔记本重装系统并跑起来。
+
+## 这周做了什么
+
+- 拿出老笔记本，重装 CachyOS
+- 部署大龙虾，配置 channels 和 models
+- 创建本项目
+
+## 下一步
+
+烹饪这只大龙虾。

--- a/src/content/writing/now-2026-02-01/index.md
+++ b/src/content/writing/now-2026-02-01/index.md
@@ -1,0 +1,19 @@
+---
+title: "Now: 站点从空页面升级到可持续更新（Astro + RSS + Pages）"
+description: "把个人站点从空页面升级到 Astro + Writing + RSS + Pages 部署。"
+pubDate: 2026-02-01
+tags: ["now", "site", "astro", "github-pages", "writing"]
+draft: false
+---
+
+一句话：把个人站点从空页面升级到 Astro + Writing + RSS + Pages 部署。
+
+## 这周做了什么
+
+- 完成首页定位（代码/游戏/臭屁宝）
+- 文章阅读体验增强（排版/TOC/SEO）
+- 准备 Games/Life/Now 占位页
+
+## 下一步
+
+合并 PR，继续优化文章页与站内搜索。

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -1,5 +1,11 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { getCollection } from 'astro:content';
+
+const posts = (await getCollection('writing'))
+  .filter((p) => !p.data.draft)
+  .filter((p) => (p.data.tags ?? []).includes('now'))
+  .sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime());
 ---
 
 <BaseLayout title="Now | 唐靖凯" description="我最近在做什么（短更新）">
@@ -7,39 +13,31 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <h2>Now</h2>
     <p style="color: var(--muted); margin-top: 10px;">
       这里是短更新区：记录我最近在做什么、学到什么、下一步计划。<br />
-      格式：日期 → 一句话结论 → 3 个 bullet → 下一步。
+      每条 Now 都是一篇文章（带 tag：<code>now</code>）。
     </p>
 
-    <div style="margin-top: 24px; display: grid; gap: 20px;">
+    <div style="margin-top: 24px; display: grid; gap: 16px;">
+      {posts.map((post) => (
+        <article class="project-card" style="transform:none;">
+          <div style="display:flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 8px;">
+            <h3 style="margin:0;">
+              <a href={`/writing/${post.slug.replace(/\/index$/, '')}/`} style="color: var(--text); text-decoration:none;">
+                {post.data.pubDate.toISOString().slice(0, 10)} · {post.data.title.replace(/^Now:\s*/, '')}
+              </a>
+            </h3>
+            <span style="color: var(--primary); font-size: 0.85rem;">Now</span>
+          </div>
 
-      <article class="project-card" style="transform:none;">
-        <div style="display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 8px;">
-          <h3>2026-02-01</h3>
-          <span style="color: var(--primary); font-size: 0.85rem;">Website / AI / Life</span>
-        </div>
-        <p style="margin-top: 8px;">把个人站点从空页面升级到 Astro + Writing + RSS + Pages 部署。</p>
-        <ul style="margin: 12px 0 0 18px; color: var(--muted); font-size: 0.92rem; line-height: 1.6;">
-          <li>完成首页定位（代码/游戏/臭屁宝）</li>
-          <li>文章阅读体验增强（排版/TOC/SEO）</li>
-          <li>准备 Games/Life/Now 占位页</li>
-        </ul>
-        <p style="margin-top: 10px;"><strong>下一步：</strong>合并 PR，继续优化文章页与站内搜索。</p>
-      </article>
+          {post.data.description ? <p style="margin-top: 8px; color: var(--muted);">{post.data.description}</p> : null}
 
-      <article class="project-card" style="transform:none;">
-        <div style="display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 8px;">
-          <h3>2026-01-31</h3>
-          <span style="color: var(--primary); font-size: 0.85rem;">OpenClaw / Setup</span>
-        </div>
-        <p style="margin-top: 8px;">周末试用 OpenClaw「大龙虾」：把老笔记本重装系统并跑起来。</p>
-        <ul style="margin: 12px 0 0 18px; color: var(--muted); font-size: 0.92rem; line-height: 1.6;">
-          <li>拿出老笔记本，重装 CachyOS</li>
-          <li>部署大龙虾，配置 channels 和 models</li>
-          <li>创建本项目</li>
-        </ul>
-        <p style="margin-top: 10px;"><strong>下一步：</strong>烹饪这只大龙虾。</p>
-      </article>
+          <div style="margin-top: 10px; display:flex; gap: 10px; flex-wrap: wrap;">
+            <a href={`/writing/${post.slug.replace(/\/index$/, '')}/`}>阅读全文 →</a>
+            <a href="/tags/now/" style="color: var(--muted);">#now</a>
+          </div>
+        </article>
+      ))}
 
+      {posts.length === 0 ? <p style="color: var(--muted);">还没有 Now 更新。</p> : null}
     </div>
   </section>
 </BaseLayout>


### PR DESCRIPTION
## Now 改造

- Now 不再是手写卡片，而是“文章化”：Now 每条都是一篇 writing 文章（tag 包含 `now`）
- `/now` 页面改为自动读取 `writing` 集合中 tag 含 `now` 的文章列表

## 已迁移

- 2026-02-01 → `src/content/writing/now-2026-02-01/index.md`
- 2026-01-31 → `src/content/writing/now-2026-01-31/index.md`

## 验证

- `npm run build` 通过
- 生成 `/tags/now/`
- `/now` 页面包含两条 Now 更新，并链接到对应文章页
