### PR TITLE
Add: by/source frontmatter (authorship + attribution)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,9 @@ dist/
 # dependencies
 node_modules/
 
-# generated writing assets (copied from src/content/writing/**)
+# generated content assets (copied from src/content/{writing,now}/**)
 public/writing/
+public/now/
 
 # logs
 npm-debug.log*

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -4,6 +4,19 @@ description: "一句话摘要，概括这篇文章解决了什么问题或带来
 pubDate: YYYY-MM-DD
 tags: ["tag1", "tag2", "tag3"]
 draft: false
+
+# 署名与来源（建议填写）
+by:
+  role: coauthored # owner | assistant | coauthored
+  name: "唐靖凯"   # 或 "获麟"
+  note: "主人提供要点，获麟整理成文" # 可选
+source:
+  kind: original   # original | repost | translation | notes
+  # title: "原文标题"        # 可选
+  # url: "https://..."       # 可选
+  # author: "原作者"         # 可选
+  # license: "CC BY 4.0"     # 可选
+  # accessedAt: "2026-02-02" # 可选
 ---
 
 ## 结论（必填）

--- a/scripts/new-now.mjs
+++ b/scripts/new-now.mjs
@@ -108,6 +108,13 @@ async function main() {
     `pubDate: ${JSON.stringify(isoShanghai(new Date()))}`,
     `tags: [${tags.map((t) => JSON.stringify(t)).join(', ')}]`,
     'draft: false',
+    '',
+    'by:',
+    '  role: assistant',
+    '  name: 获麟',
+    '  note: "根据主人需求生成 / 编辑"',
+    'source:',
+    '  kind: original',
     '---',
     '',
   ].join('\n');

--- a/scripts/new-post.mjs
+++ b/scripts/new-post.mjs
@@ -89,6 +89,13 @@ async function main() {
     `pubDate: ${JSON.stringify(pubDate)}`,
     `tags: [${tags.map((t) => JSON.stringify(t)).join(', ')}]`,
     'draft: true',
+    '',
+    'by:',
+    '  role: coauthored',
+    '  name: 唐靖凯',
+    '  note: "主人提供要点，获麟整理成文"',
+    'source:',
+    '  kind: original',
     '---',
     '',
   ].join('\n');

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -7,6 +7,27 @@ const baseSchema = z.object({
   updatedDate: z.coerce.date().optional(),
   tags: z.array(z.string()).default([]),
   draft: z.boolean().default(false),
+
+  // Authorship
+  by: z
+    .object({
+      role: z.enum(['owner', 'assistant', 'coauthored']),
+      name: z.string(),
+      note: z.string().optional(),
+    })
+    .optional(),
+
+  // Source / attribution
+  source: z
+    .object({
+      kind: z.enum(['original', 'repost', 'translation', 'notes']).default('original'),
+      title: z.string().optional(),
+      url: z.string().url().optional(),
+      author: z.string().optional(),
+      license: z.string().optional(),
+      accessedAt: z.string().optional(),
+    })
+    .optional(),
 });
 
 const writing = defineCollection({


### PR DESCRIPTION
- content schema 增加可选字段：by{role,name,note} 与 source{kind,...}（默认 kind=original）\n- new:post/new:now 自动填入 by/source\n- TEMPLATE.md 增加示例\n- .gitignore 忽略 public/now（构建生成资源）