### PR TITLE
Fix: new:now default slug uses seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,12 @@ src/content/writing/
 npm run new:post
 npm run new:post -- --title "标题" --slug my-post --tags "ai,tooling" --date 2026-02-02
 
-# 新建 Now（独立 collection，slug=YYYYMMDDHHmm-<suffix>，Asia/Shanghai）
+# 新建 Now（独立 collection，默认 slug=YYYYMMDDHHmmss，Asia/Shanghai）
 npm run new:now
 npm run new:now -- --title "今天做了什么" --tags "openclaw,setup"
+
+# 可选：把标题附到 slug 后（URL 更长但更可读）
+npm run new:now -- --title "今天做了什么" --tags "openclaw,setup" --withTitle
 
 # 同步文章/Now 资源到 public（构建/开发前可单独跑）
 npm run sync:assets

--- a/scripts/new-now.mjs
+++ b/scripts/new-now.mjs
@@ -21,7 +21,7 @@ function pad2(n) {
 }
 
 function nowIdShanghai(date = new Date()) {
-  // Asia/Shanghai UTC+8, format: YYYYMMDDHHmm
+  // Asia/Shanghai UTC+8, format: YYYYMMDDHHmmss
   const utcMs = date.getTime();
   const shMs = utcMs + 8 * 60 * 60 * 1000;
   const d = new Date(shMs);
@@ -30,7 +30,8 @@ function nowIdShanghai(date = new Date()) {
   const dd = pad2(d.getUTCDate());
   const hh = pad2(d.getUTCHours());
   const mi = pad2(d.getUTCMinutes());
-  return `${yyyy}${mm}${dd}${hh}${mi}`;
+  const ss = pad2(d.getUTCSeconds());
+  return `${yyyy}${mm}${dd}${hh}${mi}${ss}`;
 }
 
 function isoShanghai(date = new Date()) {
@@ -78,11 +79,14 @@ async function main() {
 
   const title = args.title && args.title !== 'true' ? args.title : await rl.question('Now title: ');
   const tagsRaw = args.tags && args.tags !== 'true' ? args.tags : await rl.question('Tags (comma-separated, optional): ');
+  const withTitle = args.withTitle === 'true' || args['with-title'] === 'true';
+  const slugArg = args.slug && args.slug !== 'true' ? args.slug : null;
   await rl.close();
 
   const id = nowIdShanghai(new Date());
   const suffix = slugify(title);
-  const slug = suffix ? `${id}-${suffix}` : id;
+  // Default: short, stable id only. Optionally append title or override slug.
+  const slug = slugArg ? slugify(slugArg) : withTitle && suffix ? `${id}-${suffix}` : id;
 
   const postDir = path.join(NOW_DIR, slug);
   const mdPath = path.join(postDir, 'index.md');


### PR DESCRIPTION
- new:now 默认目录名改为 YYYYMMDDHHmmss（Asia/Shanghai），避免同一分钟多条冲突且 URL 更短\n- 可选 --withTitle 把标题附到 slug 后（可读性更强但 URL 更长）\n- README 同步更新示例