### PR TITLE
Fix: search page actually loads Pagefind on GitHub Pages

### DIFF
--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -21,7 +21,7 @@ const description = '站内搜索（离线索引，纯静态）。';
     // Pagefind assets are generated at build time into /pagefind.
     // On GitHub Pages (project pages), we must respect BASE_URL.
     (async () => {
-      const base = import.meta.env.BASE_URL || '/';
+      const base = import.meta.env.BASE_URL;
       try {
         const uiUrl = `${base}pagefind/pagefind-ui.js`;
         const { PagefindUI } = await import(/* @vite-ignore */ uiUrl);
@@ -31,7 +31,17 @@ const description = '站内搜索（离线索引，纯静态）。';
         });
       } catch (e) {
         const el = document.querySelector('#pagefind');
-        if (el) el.innerHTML = '<p>搜索组件加载失败：请确认构建产物包含 <code>/pagefind</code> 目录。</p>';
+        if (el) {
+          // Build error message safely without using innerHTML
+          el.textContent = '';
+          const p = document.createElement('p');
+          p.append(document.createTextNode('搜索组件加载失败：请确认构建产物包含 '));
+          const code = document.createElement('code');
+          code.textContent = '/pagefind';
+          p.append(code);
+          p.append(document.createTextNode(' 目录。'));
+          el.appendChild(p);
+        }
         console.error('[search] failed to load pagefind', e);
       }
     })();


### PR DESCRIPTION
- Search 页面 Pagefind 资源路径改为使用 import.meta.env.BASE_URL\n- 增加加载失败 fallback 提示（便于排错）\n\n原因：GitHub Pages 项目页（或 base 不为 /）时，原来的 /pagefind/... 会 404，导致只有静态页面没有搜索能力。