### PR TITLE
Fix: mobile-friendly feed/list layout

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -45,6 +45,45 @@ const canonicalUrl = canonical
 
     <title>{title}</title>
     <link rel="stylesheet" href="/styles.css" />
+
+    <style>
+      /* Feed/List cards: responsive layout for optional cover images */
+      .content-card {
+        transform: none;
+      }
+
+      .content-card__grid {
+        display: grid;
+      }
+
+      .content-card__grid.has-cover {
+        grid-template-columns: 140px 1fr;
+        gap: 14px;
+        align-items: start;
+      }
+
+      .content-card__thumb {
+        width: 140px;
+        height: 92px;
+        object-fit: cover;
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        display: block;
+      }
+
+      @media (max-width: 560px) {
+        .content-card__grid.has-cover {
+          grid-template-columns: 1fr;
+          gap: 10px;
+        }
+
+        .content-card__thumb {
+          width: 100%;
+          height: 180px;
+        }
+      }
+    </style>
+
     <slot name="head" />
   </head>
   <body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -107,15 +107,15 @@ const feed = [...writing.map((p) => ({ kind: 'writing' as const, post: p })), ..
         const coverRaw = pickCover(post);
         const cover = coverRaw ? resolveMaybeRelativeUrl(coverRaw, href) : null;
         return (
-          <article class="feed-card project-card" style="transform:none;">
-            <div style={`display:grid; ${cover ? 'grid-template-columns: 140px 1fr; gap: 14px; align-items: start;' : ''}`}>
+          <article class="feed-card project-card content-card">
+            <div class={`content-card__grid ${cover ? 'has-cover' : ''}`}>
               {cover ? (
                 <a href={href} style="display:block;">
                   <img
+                    class="content-card__thumb"
                     src={cover}
                     alt={title}
                     loading="lazy"
-                    style="width: 140px; height: 92px; object-fit: cover; border-radius: 12px; border: 1px solid var(--border);"
                   />
                 </a>
               ) : null}

--- a/src/pages/now/index.astro
+++ b/src/pages/now/index.astro
@@ -22,15 +22,15 @@ const posts = (await getCollection('now'))
         const coverRaw = pickCover(post);
         const cover = coverRaw ? resolveMaybeRelativeUrl(coverRaw, href) : null;
         return (
-          <article class="project-card" style="transform:none;">
-            <div style={`display:grid; ${cover ? 'grid-template-columns: 140px 1fr; gap: 14px; align-items: start;' : ''}`}>
+          <article class="project-card content-card">
+            <div class={`content-card__grid ${cover ? 'has-cover' : ''}`}>
               {cover ? (
                 <a href={href} style="display:block;">
                   <img
+                    class="content-card__thumb"
                     src={cover}
                     alt={post.data.title}
                     loading="lazy"
-                    style="width: 140px; height: 92px; object-fit: cover; border-radius: 12px; border: 1px solid var(--border);"
                   />
                 </a>
               ) : null}

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -21,15 +21,15 @@ const posts = (await getCollection('writing'))
         const coverRaw = pickCover(post);
         const cover = coverRaw ? resolveMaybeRelativeUrl(coverRaw, href) : null;
         return (
-          <article class="project-card" style="transform:none;">
-            <div style={`display:grid; ${cover ? 'grid-template-columns: 140px 1fr; gap: 14px; align-items: start;' : ''}`}>
+          <article class="project-card content-card">
+            <div class={`content-card__grid ${cover ? 'has-cover' : ''}`}>
               {cover ? (
                 <a href={href} style="display:block;">
                   <img
+                    class="content-card__thumb"
                     src={cover}
                     alt={post.data.title}
                     loading="lazy"
-                    style="width: 140px; height: 92px; object-fit: cover; border-radius: 12px; border: 1px solid var(--border);"
                   />
                 </a>
               ) : null}


### PR DESCRIPTION
- Writing/Now/首页 feed 卡片改为统一 class（content-card*），去掉硬编码 inline grid
- 移动端（<=560px）：有图卡片改为上下布局，图片宽 100%，高度 180px
- 无图卡片保持单列文本
- 已通过 npm run build
