### PR TITLE
Fix: mobile feed thumbnail sizing

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -78,9 +78,10 @@ const canonicalUrl = canonical
           gap: 10px;
         }
 
-        .content-card .content-card__thumb {
-          width: 100% !important;
-          height: 180px !important;
+        /* More specific selector to win the cascade without !important */
+        .project-card.content-card .content-card__thumb {
+          width: 100%;
+          height: 180px;
         }
       }
     </style>


### PR DESCRIPTION
- 修复：移动端 feed/list 缩略图尺寸规则偶发不生效的问题
- 提升 CSS 选择器优先级，并在移动端对 width/height 加 !important（避免被其它样式覆盖）
- 已通过 npm run build
