### PR TITLE
Fix: mobile feed CSS scoping (make global)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -46,7 +46,7 @@ const canonicalUrl = canonical
     <title>{title}</title>
     <link rel="stylesheet" href="/styles.css" />
 
-    <style>
+    <style is:global>
       /* Feed/List cards: responsive layout for optional cover images */
       .content-card {
         transform: none;


### PR DESCRIPTION
- 修复：移动端 feed/list 缩略图尺寸规则不生效
- 原因：BaseLayout 内联 <style> 被 Astro 自动 scope（data-astro-cid），导致规则匹配不到页面里渲染的卡片元素
- 处理：把这段样式改为 <style is:global>，确保跨页面元素都能命中
- 已通过 npm run build
