### PR TITLE
Perf: tune image loading priorities

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,7 @@ const feed = [...writing.map((p) => ({ kind: 'writing' as const, post: p })), ..
         <br />写代码、打游戏、带娃。
       </h1>
 
-      <img class="avatar" src="/images/avatar.jpg" alt="唐靖凯" loading="eager" />
+      <img class="avatar" src="/images/avatar.jpg" alt="唐靖凯" loading="eager" decoding="async" fetchpriority="high" />
       <p class="lead">
         Java 后端工程师（2018 起全职）｜软件工程硕士。
         关注 AI 大模型应用侧：把新工具落到真实场景；也会记录主机游戏与奶爸日常。
@@ -116,6 +116,8 @@ const feed = [...writing.map((p) => ({ kind: 'writing' as const, post: p })), ..
                     src={cover}
                     alt={title}
                     loading="lazy"
+                    decoding="async"
+                    fetchpriority="low"
                   />
                 </a>
               ) : null}

--- a/src/pages/now/index.astro
+++ b/src/pages/now/index.astro
@@ -31,6 +31,8 @@ const posts = (await getCollection('now'))
                     src={cover}
                     alt={post.data.title}
                     loading="lazy"
+                    decoding="async"
+                    fetchpriority="low"
                   />
                 </a>
               ) : null}

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -30,6 +30,8 @@ const posts = (await getCollection('writing'))
                     src={cover}
                     alt={post.data.title}
                     loading="lazy"
+                    decoding="async"
+                    fetchpriority="low"
                   />
                 </a>
               ) : null}


### PR DESCRIPTION
- Added decoding/fetchpriority hints for images to improve perceived performance.
  - Hero avatar: decoding=async + fetchpriority=high.
  - Feed/list cover images: decoding=async + fetchpriority=low.

How to verify:
- npm run build
- Load homepage and inspect network/priority: avatar should be high priority; list images should be low.
