### PR TITLE
Chore: add dist size audit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ npm run build
 npm run preview
 ```
 
+## 性能/体积审计
+
+```bash
+# 构建 + 输出 dist 体积 Top 列表（含 gzip 粗略统计）
+npm run audit:size
+```
+
 说明：如果项目启用了 Pagefind，那么 `npm run build` 会在 `astro build` 之后自动运行 Pagefind，为站内搜索生成索引（输出到 `dist/pagefind/`）。
 
 ## 部署

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "publish:writing": "node scripts/publish-writing.mjs",
     "publish:now": "node scripts/publish-now.mjs",
     "build": "npm run sync:assets && astro build && pagefind --site dist",
+    "audit:size": "node scripts/audit-size.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/scripts/audit-size.mjs
+++ b/scripts/audit-size.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// @ts-check
+
+import { execSync } from 'node:child_process';
+
+function sh(cmd) {
+  return execSync(cmd, { stdio: 'pipe', encoding: 'utf8' }).trimEnd();
+}
+
+function hr(title) {
+  console.log(`\n=== ${title} ===`);
+}
+
+try {
+  hr('Build');
+  execSync('npm run build', { stdio: 'inherit' });
+
+  hr('dist total');
+  console.log(sh('du -sh dist'));
+
+  hr('largest files (dist)');
+  // show top 25 by size
+  console.log(sh("du -ah dist | sort -hr | head -n 25"));
+
+  hr('styles.css size (raw/gzip)');
+  console.log(sh("ls -lh dist/styles.css"));
+  console.log(sh("gzip -c dist/styles.css | wc -c | awk '{print $1 " + '" bytes"' + "}'"));
+
+  hr('quick-search module size (raw/gzip)');
+  if (sh("test -f dist/quick-search.mjs && echo yes || echo no").includes('yes')) {
+    console.log(sh('ls -lh dist/quick-search.mjs'));
+    console.log(sh("gzip -c dist/quick-search.mjs | wc -c | awk '{print $1 " + '" bytes"' + "}'"));
+  } else {
+    console.log('dist/quick-search.mjs not found (expected for static output? check build config)');
+  }
+
+  hr('pagefind assets size (raw)');
+  if (sh("test -d dist/pagefind && echo yes || echo no").includes('yes')) {
+    console.log(sh("du -sh dist/pagefind"));
+    console.log(sh("du -ah dist/pagefind | sort -hr | head -n 15"));
+  } else {
+    console.log('dist/pagefind not found');
+  }
+} catch (e) {
+  console.error('\n[audit-size] failed');
+  console.error(e?.message ?? e);
+  process.exit(1);
+}


### PR DESCRIPTION
- Adds `npm run audit:size` to build the site and print a simple dist size report:
  - total dist size
  - top largest files
  - gzip sizes for styles.css and quick-search module
  - pagefind asset breakdown

Why:
- Supports the P3 task "CSS/JS 体积审计" with a repeatable command.

How to verify:
- npm run audit:size
