### PR TITLE
Feat: publish:writing:confirm (flip draft true->false + publish)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ npm run dev:watch
 5. [x] 404 体验：增强 404 页面（返回上一页/直接搜索入口等）
 6. [x] 自动化：`new:post / new:now / sync:assets / dev:watch`
 7. [x] 发布命令（Writing 草稿）：一键 commit+push main（不走 PR，`npm run publish:writing:draft -- --slug <slug>`）
-8. [x] 发布命令（Writing 发布）：手动确认后再 commit+push main（`npm run publish:writing:final -- --slug <slug>`）
+8. [x] 发布命令（Writing 发布）：手动确认后再 commit+push main（两种方式任选其一）
+   - 方式 A：你手动把 `draft: false` 改好 → `npm run publish:writing:final -- --slug <slug>`
+   - 方式 B：用脚本自动把 `draft:true -> false` 并发布 → `npm run publish:writing:confirm -- --slug <slug>`
 9. [x] 发布命令：Now 一键 commit+push main（不走 PR，`npm run publish:now -- --slug <slug>`）
 10. [x] 快捷搜索：Cmd/Ctrl+K 弹窗搜索
 11. [x] 性能优化：字体加载优化（移除 CSS @import，改为 preconnect + link）

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "publish:writing": "node scripts/publish-writing.mjs",
     "publish:writing:draft": "node scripts/publish-writing-draft.mjs",
     "publish:writing:final": "node scripts/publish-writing-final.mjs",
+    "publish:writing:confirm": "node scripts/publish-writing-confirm.mjs",
     "publish:now": "node scripts/publish-now.mjs",
     "check": "astro check",
     "build": "npm run sync:assets && astro build && pagefind --site dist",

--- a/scripts/publish-writing-confirm.mjs
+++ b/scripts/publish-writing-confirm.mjs
@@ -1,0 +1,81 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+
+function sh(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { stdio: 'inherit', ...opts });
+  if (r.status !== 0) process.exit(r.status ?? 1);
+}
+
+function shOut(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { encoding: 'utf8', ...opts });
+  if (r.status !== 0) throw new Error(r.stderr || `Command failed: ${cmd} ${args.join(' ')}`);
+  return String(r.stdout).trim();
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const key = a.slice(2);
+    const val = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[++i] : 'true';
+    out[key] = val;
+  }
+  return out;
+}
+
+const repo = 'JingkaiTang/JingkaiTang.github.io';
+const args = parseArgs(process.argv);
+
+const slug = args.slug && args.slug !== 'true' ? args.slug : null;
+const title = args.title && args.title !== 'true' ? args.title : null;
+const message = args.message && args.message !== 'true' ? args.message : null;
+
+if (!slug) {
+  console.error('Missing --slug <slug>.');
+  process.exit(2);
+}
+
+const postDir = `src/content/writing/${slug}`;
+const postPath = `${postDir}/index.md`;
+if (!fs.existsSync(postPath)) {
+  console.error(`Post not found: ${postPath}`);
+  process.exit(2);
+}
+
+// Must be clean; we will modify + commit directly to main.
+const porcelain = shOut('git', ['status', '--porcelain']);
+if (porcelain) {
+  console.error('Working tree not clean. Commit/stash your changes first.');
+  process.exit(2);
+}
+
+let md = fs.readFileSync(postPath, 'utf8');
+const isDraft = /\n\s*draft:\s*true\s*\n/i.test(md);
+if (!isDraft) {
+  console.error('Post is already draft:false (or missing draft flag). This command is only for confirming publish from draft:true -> draft:false.');
+  process.exit(2);
+}
+
+// Flip to draft:false
+md = md.replace(/\n\s*draft:\s*true\s*\n/i, '\n\ndraft: false\n');
+fs.writeFileSync(postPath, md, 'utf8');
+
+sh('git', ['checkout', 'main']);
+sh('git', ['pull', '--ff-only', 'origin', 'main']);
+
+// Verify build still works
+sh('npm', ['run', 'build']);
+
+sh('git', ['add', postDir]);
+
+const msg = message
+  ? message
+  : title
+    ? `Writing: ${title}`
+    : `Writing: ${slug}`;
+
+sh('git', ['commit', '-m', msg]);
+sh('git', ['push', `ssh://git@ssh.github.com:443/${repo}.git`, 'main']);
+
+console.log(`Published Writing: /writing/${slug}/`);


### PR DESCRIPTION
- Add helper script `npm run publish:writing:confirm -- --slug <slug>`
  - Verifies the post is currently draft:true
  - Flips it to draft:false
  - Builds
  - Commits + pushes to main

Why:
- Matches the new workflow: drafts can be pushed to main for preview, final publish is an explicit confirmation step.

How to verify:
- Set a Writing post to draft:true
- Run: npm run publish:writing:confirm -- --slug <slug>
