### PR TITLE
Chore: auto-ensure Pages deploy catches up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,9 @@
   - `chore/...` 杂项/整理/迁移
 - **提交粒度**：一个 PR 做一件事（例如 Now 架构改造不要夹杂首页文案）。
 - **发布策略（重要）**：
-  - **Writing（长文）必须走 PR**：开分支 → 提交 → PR → review → merge。
+  - **Writing（长文）不走 PR**：草稿阶段允许直接 commit 到 `main` 用于预览；最终发布需主人确认。
+    - 草稿：`npm run publish:writing:draft -- --slug <slug>`（保持 `draft:true`，不进 feed，但可通过链接访问）
+    - 发布：主人确认后，用 `npm run publish:writing:confirm -- --slug <slug>`（自动 `draft:true -> false` 并发布），或主人手动改 `draft:false` 后跑 `publish:writing:final`
   - **Now（短更新）不需要 PR**：允许直接 commit 到 `main` 并 push（以速度优先）。
 - **合并前自检**：
   - `npm install`（或 `npm ci`）

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ npm run preview
 ```bash
 # 构建 + 输出 dist 体积 Top 列表（含 gzip 粗略统计）
 npm run audit:size
+
+# 确保 GitHub Pages 部署追上 main 最新提交（必要时自动触发 workflow_dispatch）
+npm run deploy:ensure
 ```
 
 补充：代码高亮目前依赖 Astro 的构建期处理（无额外前端 runtime JS）。如果未来引入 Shiki/Prism 主题 CSS 或客户端高亮，再把该部分纳入 audit:size 的关注项。

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "publish:writing:draft": "node scripts/publish-writing-draft.mjs",
     "publish:writing:final": "node scripts/publish-writing-final.mjs",
     "publish:writing:confirm": "node scripts/publish-writing-confirm.mjs",
+    "deploy:ensure": "node scripts/ensure-pages-deploy.mjs --wait",
     "publish:now": "node scripts/publish-now.mjs",
     "check": "astro check",
     "build": "npm run sync:assets && astro build && pagefind --site dist",

--- a/scripts/ensure-pages-deploy.mjs
+++ b/scripts/ensure-pages-deploy.mjs
@@ -1,0 +1,81 @@
+import { spawnSync } from 'node:child_process';
+
+function shOut(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { encoding: 'utf8', ...opts });
+  if (r.status !== 0) {
+    throw new Error(r.stderr || `Command failed: ${cmd} ${args.join(' ')}`);
+  }
+  return String(r.stdout).trim();
+}
+
+function sh(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { stdio: 'inherit', ...opts });
+  if (r.status !== 0) process.exit(r.status ?? 1);
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const key = a.slice(2);
+    const val = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[++i] : 'true';
+    out[key] = val;
+  }
+  return out;
+}
+
+const repo = 'JingkaiTang/JingkaiTang.github.io';
+const args = parseArgs(process.argv);
+
+const workflow = args.workflow && args.workflow !== 'true' ? args.workflow : 'pages.yml';
+const branch = args.branch && args.branch !== 'true' ? args.branch : 'main';
+const wait = args.wait === 'true' || args.w === 'true';
+
+// main HEAD sha
+const headSha = shOut('gh', ['api', `repos/${repo}/commits/${branch}`, '--jq', '.sha']);
+
+// latest workflow run head sha
+const latest = shOut('gh', [
+  'api',
+  `repos/${repo}/actions/workflows/${workflow}/runs?branch=${branch}&per_page=1`,
+  '--jq',
+  '.workflow_runs[0] | {id, head_sha, status, conclusion, html_url}',
+]);
+
+let latestJson;
+try {
+  latestJson = JSON.parse(latest);
+} catch {
+  latestJson = null;
+}
+
+const latestSha = latestJson?.head_sha;
+const latestId = latestJson?.id;
+
+if (latestSha === headSha) {
+  console.log(`[ensure-pages-deploy] OK: latest workflow run already matches ${branch}@${headSha}`);
+  if (latestId) console.log(`[ensure-pages-deploy] run: ${latestJson.html_url ?? `https://github.com/${repo}/actions/runs/${latestId}`}`);
+  process.exit(0);
+}
+
+console.log(`[ensure-pages-deploy] MISMATCH: ${branch}@${headSha} is not deployed by latest run (latest head_sha=${latestSha ?? 'null'})`);
+console.log('[ensure-pages-deploy] Triggering workflow_dispatch to deploy latest main...');
+
+sh('gh', ['workflow', 'run', 'Deploy to GitHub Pages', '--repo', repo, '--ref', branch]);
+
+// Try to fetch the newest run id
+try {
+  const newId = shOut('gh', [
+    'api',
+    `repos/${repo}/actions/workflows/${workflow}/runs?branch=${branch}&per_page=1`,
+    '--jq',
+    '.workflow_runs[0].id',
+  ]);
+  console.log(`[ensure-pages-deploy] triggered run: https://github.com/${repo}/actions/runs/${newId}`);
+  if (wait) {
+    sh('gh', ['run', 'watch', String(newId), '--repo', repo]);
+  }
+} catch (e) {
+  console.log('[ensure-pages-deploy] triggered, but failed to fetch run id (non-fatal).');
+}

--- a/scripts/publish-now.mjs
+++ b/scripts/publish-now.mjs
@@ -61,4 +61,7 @@ sh('git', ['commit', '-m', msg]);
 // Push main using ssh over 443
 sh('git', ['push', `ssh://git@ssh.github.com:443/${repo}.git`, 'main']);
 
+// Ensure Pages deploy catches up (GitHub Actions may occasionally miss/delay pushes)
+sh('node', ['scripts/ensure-pages-deploy.mjs', '--workflow', 'pages.yml', '--branch', 'main']);
+
 console.log(`Published Now: /now/${slug}/`);

--- a/scripts/publish-writing-confirm.mjs
+++ b/scripts/publish-writing-confirm.mjs
@@ -78,4 +78,7 @@ const msg = message
 sh('git', ['commit', '-m', msg]);
 sh('git', ['push', `ssh://git@ssh.github.com:443/${repo}.git`, 'main']);
 
+// Ensure Pages deploy catches up (GitHub Actions may occasionally miss/delay pushes)
+sh('node', ['scripts/ensure-pages-deploy.mjs', '--workflow', 'pages.yml', '--branch', 'main']);
+
 console.log(`Published Writing: /writing/${slug}/`);

--- a/scripts/publish-writing-draft.mjs
+++ b/scripts/publish-writing-draft.mjs
@@ -72,4 +72,7 @@ sh('git', ['commit', '-m', msg]);
 // Push main using ssh over 443
 sh('git', ['push', `ssh://git@ssh.github.com:443/${repo}.git`, 'main']);
 
+// Ensure Pages deploy catches up (GitHub Actions may occasionally miss/delay pushes)
+sh('node', ['scripts/ensure-pages-deploy.mjs', '--workflow', 'pages.yml', '--branch', 'main']);
+
 console.log(`Draft published (hidden from feed): /writing/${slug}/`);

--- a/scripts/publish-writing-final.mjs
+++ b/scripts/publish-writing-final.mjs
@@ -68,4 +68,7 @@ sh('git', ['commit', '-m', msg]);
 
 sh('git', ['push', `ssh://git@ssh.github.com:443/${repo}.git`, 'main']);
 
+// Ensure Pages deploy catches up (GitHub Actions may occasionally miss/delay pushes)
+sh('node', ['scripts/ensure-pages-deploy.mjs', '--workflow', 'pages.yml', '--branch', 'main']);
+
 console.log(`Published Writing: /writing/${slug}/`);


### PR DESCRIPTION
- Add `npm run deploy:ensure` (checks latest Pages workflow run head_sha; triggers workflow_dispatch if it lags behind main).
- Update publish scripts (Now + Writing draft/final/confirm) to call ensure-pages-deploy after pushing main.
- Update AGENTS.md + README.md to document new workflow.

Why:
- We observed recent merges where Pages did not immediately reflect the latest main; this makes deploy self-healing.

How to verify:
- Run: npm run deploy:ensure
- Publish a Now/Writing and observe it auto-triggers deploy if needed.
