### PR TITLE
Feat: editing mechanism for Writing/Now (updatedDate + draft preview)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,13 @@
 
 ## 5) 命令行工具（脚本约定）
 
+### 编辑机制（Editing）
+
+- 编辑 Writing / Now：直接修改对应 `index.md`，然后运行编辑脚本写入 `updatedDate`（精确到秒）：
+  - `npm run edit:writing -- --slug <writing-slug>`
+  - `npm run edit:now -- --slug <now-slug>`
+- 展示规则：详情页会显示“更新于”；草稿会显示“草稿”标识并 noindex。
+
 - 新建 Writing：
   - `npm run new:post`
 - 新建 Now：

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ npm run new:post -- --title "标题" --slug my-post --tags "ai,tooling" --date 2
 npm run new:now
 npm run new:now -- --title "今天做了什么" --tags "openclaw,setup"
 
+# 编辑 Writing / Now（会自动写入 updatedDate，精确到秒）
+npm run edit:writing -- --slug <writing-slug>
+npm run edit:now -- --slug <now-slug>
+
 # 可选：把标题附到 slug 后（URL 更长但更可读）
 npm run new:now -- --title "今天做了什么" --tags "openclaw,setup" --withTitle
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "publish:writing:draft": "node scripts/publish-writing-draft.mjs",
     "publish:writing:final": "node scripts/publish-writing-final.mjs",
     "publish:writing:confirm": "node scripts/publish-writing-confirm.mjs",
+    "edit:writing": "node scripts/edit-writing.mjs",
+    "edit:now": "node scripts/edit-now.mjs",
     "deploy:ensure": "node scripts/ensure-pages-deploy.mjs --wait",
     "publish:now": "node scripts/publish-now.mjs",
     "check": "astro check",

--- a/scripts/edit-now.mjs
+++ b/scripts/edit-now.mjs
@@ -1,0 +1,80 @@
+import fs from 'node:fs';
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const key = a.slice(2);
+    const val = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[++i] : 'true';
+    out[key] = val;
+  }
+  return out;
+}
+
+function pad2(n) {
+  return String(n).padStart(2, '0');
+}
+
+function isoShanghai(date = new Date()) {
+  // Return ISO-ish with +08:00 offset, second precision
+  const utcMs = date.getTime();
+  const shMs = utcMs + 8 * 60 * 60 * 1000;
+  const d = new Date(shMs);
+  const yyyy = d.getUTCFullYear();
+  const mm = pad2(d.getUTCMonth() + 1);
+  const dd = pad2(d.getUTCDate());
+  const hh = pad2(d.getUTCHours());
+  const mi = pad2(d.getUTCMinutes());
+  const ss = pad2(d.getUTCSeconds());
+  return `${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}+08:00`;
+}
+
+function upsertUpdatedDate(frontmatter) {
+  const updated = `updatedDate: ${JSON.stringify(isoShanghai(new Date()))}`;
+
+  if (/^updatedDate:\s*.+$/m.test(frontmatter)) {
+    return frontmatter.replace(/^updatedDate:\s*.+$/m, updated);
+  }
+  if (/^pubDate:\s*.+$/m.test(frontmatter)) {
+    return frontmatter.replace(/^pubDate:\s*.+$/m, (m) => `${m}\n${updated}`);
+  }
+  if (/^tags:\s*/m.test(frontmatter)) {
+    return frontmatter.replace(/^tags:\s*/m, `${updated}\n$&`);
+  }
+  return frontmatter.trimEnd() + `\n${updated}\n`;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const slug = args.slug && args.slug !== 'true' ? args.slug : null;
+
+  if (!slug) {
+    console.error('Missing --slug <slug>.');
+    process.exit(2);
+  }
+
+  const postPath = `src/content/now/${slug}/index.md`;
+  if (!fs.existsSync(postPath)) {
+    console.error(`Now not found: ${postPath}`);
+    process.exit(2);
+  }
+
+  const raw = fs.readFileSync(postPath, 'utf8');
+  const m = raw.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!m) {
+    console.error('Frontmatter not found (expected --- ... ---).');
+    process.exit(2);
+  }
+
+  const fm = m[1];
+  const rest = raw.slice(m[0].length);
+
+  const nextFm = upsertUpdatedDate(fm);
+  const next = `---\n${nextFm}\n---\n${rest}`;
+
+  fs.writeFileSync(postPath, next, 'utf8');
+  console.log(`Updated updatedDate: ${postPath}`);
+}
+
+main();

--- a/scripts/edit-writing.mjs
+++ b/scripts/edit-writing.mjs
@@ -1,0 +1,86 @@
+import fs from 'node:fs';
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const key = a.slice(2);
+    const val = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[++i] : 'true';
+    out[key] = val;
+  }
+  return out;
+}
+
+function pad2(n) {
+  return String(n).padStart(2, '0');
+}
+
+function isoShanghai(date = new Date()) {
+  // Return ISO-ish with +08:00 offset, second precision
+  const utcMs = date.getTime();
+  const shMs = utcMs + 8 * 60 * 60 * 1000;
+  const d = new Date(shMs);
+  const yyyy = d.getUTCFullYear();
+  const mm = pad2(d.getUTCMonth() + 1);
+  const dd = pad2(d.getUTCDate());
+  const hh = pad2(d.getUTCHours());
+  const mi = pad2(d.getUTCMinutes());
+  const ss = pad2(d.getUTCSeconds());
+  return `${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}+08:00`;
+}
+
+function upsertUpdatedDate(frontmatter) {
+  const updated = `updatedDate: ${JSON.stringify(isoShanghai(new Date()))}`;
+
+  // Replace if exists
+  if (/^updatedDate:\s*.+$/m.test(frontmatter)) {
+    return frontmatter.replace(/^updatedDate:\s*.+$/m, updated);
+  }
+
+  // Insert after pubDate if present, otherwise before tags
+  if (/^pubDate:\s*.+$/m.test(frontmatter)) {
+    return frontmatter.replace(/^pubDate:\s*.+$/m, (m) => `${m}\n${updated}`);
+  }
+
+  if (/^tags:\s*/m.test(frontmatter)) {
+    return frontmatter.replace(/^tags:\s*/m, `${updated}\n$&`);
+  }
+
+  // Fallback: append at end
+  return frontmatter.trimEnd() + `\n${updated}\n`;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const slug = args.slug && args.slug !== 'true' ? args.slug : null;
+
+  if (!slug) {
+    console.error('Missing --slug <slug>.');
+    process.exit(2);
+  }
+
+  const postPath = `src/content/writing/${slug}/index.md`;
+  if (!fs.existsSync(postPath)) {
+    console.error(`Writing not found: ${postPath}`);
+    process.exit(2);
+  }
+
+  const raw = fs.readFileSync(postPath, 'utf8');
+  const m = raw.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!m) {
+    console.error('Frontmatter not found (expected --- ... ---).');
+    process.exit(2);
+  }
+
+  const fm = m[1];
+  const rest = raw.slice(m[0].length);
+
+  const nextFm = upsertUpdatedDate(fm);
+  const next = `---\n${nextFm}\n---\n${rest}`;
+
+  fs.writeFileSync(postPath, next, 'utf8');
+  console.log(`Updated updatedDate: ${postPath}`);
+}
+
+main();

--- a/src/pages/now/[slug].astro
+++ b/src/pages/now/[slug].astro
@@ -3,31 +3,60 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getCollection, render } from 'astro:content';
 
 export async function getStaticPaths() {
+  // Include drafts so they can be previewed via direct link.
+  // Drafts are still hidden from feeds/lists elsewhere.
   const posts = await getCollection('now');
-  return posts
-    .filter((p) => !p.data.draft)
-    .map((p) => ({
-      params: { slug: p.slug.replace(/\/index$/, '') },
-      props: { post: p },
-    }));
+  return posts.map((p) => ({
+    params: { slug: p.slug.replace(/\/index$/, '') },
+    props: { post: p },
+  }));
 }
 
 const { post } = Astro.props;
 const { Content } = await render(post);
+const isDraft = Boolean(post.data.draft);
 ---
 
 <BaseLayout
-  title={`${post.data.title} | 唐靖凯`}
+  title={`${post.data.title}${isDraft ? '（草稿）' : ''} | 唐靖凯`}
   description={post.data.description}
   canonical={`/now/${post.slug.replace(/\/index$/, '')}/`}
   ogType="article"
   publishedTime={post.data.pubDate.toISOString()}
 >
+  <Fragment slot="head">
+    {isDraft ? <meta name="robots" content="noindex,nofollow" /> : null}
+  </Fragment>
+
   <section class="section glass" style="max-width: 980px;">
     <article class="post">
-      <h1 class="post-title">{post.data.title}</h1>
+      <div style="display:flex; gap: 10px; align-items: center; flex-wrap: wrap;">
+        <h1 class="post-title" style="margin:0;">{post.data.title}</h1>
+        {isDraft ? (
+          <span style="
+            font-size: 0.85rem;
+            color: var(--primary);
+            border: 1px solid rgba(124, 249, 255, 0.25);
+            border-radius: 999px;
+            padding: 2px 10px;
+            background: rgba(124, 249, 255, 0.08);
+          ">草稿</span>
+        ) : null}
+      </div>
+
+      {isDraft ? (
+        <p style="margin-top: 10px; color: var(--muted);">
+          这是一条草稿：仅用于预览，不会出现在 Now 列表/首页流中。
+        </p>
+      ) : null}
+
       <p class="post-meta">
-        {post.data.pubDate.toISOString().slice(0, 10)}
+        {post.data.pubDate.toISOString().slice(0, 19).replace('T', ' ')}
+        {post.data.updatedDate ? (
+          <>
+            {' '}· 更新于 {post.data.updatedDate.toISOString().slice(0, 19).replace('T', ' ')}
+          </>
+        ) : null}
         {post.data.tags.length ? (
           <> · {post.data.tags.map((t, i) => (
             <>

--- a/src/pages/writing/[slug].astro
+++ b/src/pages/writing/[slug].astro
@@ -54,6 +54,11 @@ const isDraft = Boolean(post.data.draft);
         ) : null}
         <p class="post-meta">
           {post.data.pubDate.toISOString().slice(0, 10)}
+          {post.data.updatedDate ? (
+            <>
+              {' '}· 更新于 {post.data.updatedDate.toISOString().slice(0, 19).replace('T', ' ')}
+            </>
+          ) : null}
           {post.data.tags.length ? (
             <> · {post.data.tags.map((t, i) => (
               <>


### PR DESCRIPTION
- Add editing scripts:
  - `npm run edit:writing -- --slug <slug>`
  - `npm run edit:now -- --slug <slug>`
  These update `updatedDate` with Asia/Shanghai time (second precision).
- Detail pages show "更新于" timestamp when `updatedDate` exists.
- Now detail pages also support draft preview via direct link and show a 草稿 badge + noindex (align with Writing behavior).
- Docs: update README + AGENTS.

How to verify:
- Edit a post, run edit script, check frontmatter updatedDate.
- Build and open the detail page: should show 更新于 with seconds.
