### PR TITLE
Fix: widen Vibe Mosaic module on desktop

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -64,8 +64,9 @@ const BASE_URL = import.meta.env.BASE_URL;
       }
       /* Footer gallery */
       .footer-gallery {
-        max-width: 1100px;
-        margin: 32px auto 18px;
+        /* Match other homepage modules: full available width inside <main> padding */
+        width: 100%;
+        margin: 32px 0 18px;
         padding: 18px 18px;
       }
 


### PR DESCRIPTION
- Adjusted the Vibe Mosaic (footer gallery) container to use full available width (match Latest/Projects modules)
- Removed the fixed max-width constraint that made it noticeably narrower on desktop

How to verify:
- Open the homepage on desktop width
- Compare Vibe Mosaic section width vs Latest/Projects sections (should align)
