### PR TITLE
UI: loosen Vibe Mosaic layout (more varied + allow repeats)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -86,12 +86,12 @@ const BASE_URL = import.meta.env.BASE_URL;
         opacity: 0.92;
       }
 
-      /* Desktop: 2-row mosaic */
+      /* Desktop: free-form mosaic (varied sizes, dense packing) */
       .footer-gallery__grid {
         display: grid;
         grid-auto-flow: dense;
         grid-template-columns: repeat(12, 1fr);
-        grid-template-rows: repeat(2, 120px);
+        grid-auto-rows: 110px;
         gap: 10px;
         overflow: hidden;
         border-radius: 18px;
@@ -114,26 +114,24 @@ const BASE_URL = import.meta.env.BASE_URL;
       }
 
       /* Size variants (assigned by JS) */
-      /* Desktop two-row fill: wide=3 cols, wide2=2 cols, default=1 col */
       .footer-gallery__img.is-wide {
         grid-column: span 3;
       }
       .footer-gallery__img.is-wide2 {
         grid-column: span 2;
       }
-      /* (Avoid row-span on desktop to keep a perfect 2-row fill) */
       .footer-gallery__img.is-tall {
-        grid-row: span 1;
+        grid-row: span 2;
       }
       .footer-gallery__img.is-big {
-        grid-column: span 3;
-        grid-row: span 1;
+        grid-column: span 4;
+        grid-row: span 2;
       }
 
       @media (max-width: 900px) {
         .footer-gallery__grid {
           grid-template-columns: repeat(8, 1fr);
-          grid-template-rows: repeat(2, 110px);
+          grid-auto-rows: 100px;
           gap: 9px;
         }
         .footer-gallery__img.is-wide {
@@ -142,9 +140,12 @@ const BASE_URL = import.meta.env.BASE_URL;
         .footer-gallery__img.is-wide2 {
           grid-column: span 2;
         }
+        .footer-gallery__img.is-tall {
+          grid-row: span 2;
+        }
         .footer-gallery__img.is-big {
-          grid-column: span 3;
-          grid-row: span 1;
+          grid-column: span 4;
+          grid-row: span 2;
         }
       }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -230,8 +230,10 @@ const pinned = (pinsData?.pins || []).slice(0, 6);
         }
 
         const isMobile = window.matchMedia('(max-width: 560px)').matches;
-        // Fixed counts for consistency
-        const N = isMobile ? 10 : 12;
+
+        // More tiles for a less "stiff" mosaic.
+        // If we don't have enough images, we allow a small amount of repetition.
+        const N = isMobile ? 14 : 24;
 
         function clearSize(img) {
           img.classList.remove('is-wide', 'is-wide2', 'is-tall', 'is-big');
@@ -243,25 +245,41 @@ const pinned = (pinsData?.pins || []).slice(0, 6);
           img.classList.add(kind);
         }
 
-        // Desktop: 2-row mosaic with guaranteed no overflow (area <= 24)
-        // Desktop: fill exactly 2 rows (12 cols x 2 rows).
-        // Spans per 6 tiles: [3,2,1,2,2,2] sum=12; repeat twice.
-        const desktopPattern = ['is-wide','is-wide2','', 'is-wide2','is-wide2','is-wide2', 'is-wide','is-wide2','', 'is-wide2','is-wide2','is-wide2'];
-        // Mobile: 2-column mixed sizes
-        const mobilePattern  = ['is-wide2', '', 'is-tall', '', 'is-wide', '', '', 'is-tall', '', ''];
-
-        imgs.forEach((img, idx) => {
-          if (idx < N) {
-            grid.appendChild(img);
-            img.style.display = '';
-
-            const base = isMobile ? mobilePattern[idx % mobilePattern.length] : desktopPattern[idx % desktopPattern.length];
-            let kind = base;
-
-            applySize(img, kind);
-          } else {
-            img.style.display = 'none';
+        function pickKind() {
+          const r = Math.random();
+          if (isMobile) {
+            // Mobile: mostly normal tiles, occasional wide/tall/big
+            if (r < 0.10) return 'is-big';
+            if (r < 0.28) return 'is-tall';
+            if (r < 0.48) return 'is-wide2';
+            if (r < 0.60) return 'is-wide';
+            return '';
           }
+
+          // Desktop: varied spans + some tall/big tiles for a more chaotic layout
+          if (r < 0.08) return 'is-big';
+          if (r < 0.20) return 'is-tall';
+          if (r < 0.45) return 'is-wide';
+          if (r < 0.70) return 'is-wide2';
+          return '';
+        }
+
+        // Build a display list of exactly N items (clone nodes to repeat if needed)
+        const display = [];
+        for (let i = 0; i < Math.min(imgs.length, N); i++) display.push(imgs[i]);
+        while (display.length < N && imgs.length > 0) {
+          const src = imgs[Math.floor(Math.random() * imgs.length)];
+          const clone = src.cloneNode(true);
+          clone.removeAttribute('data-astro-cid');
+          display.push(clone);
+        }
+
+        // Hide originals; then append our chosen mosaic tiles
+        imgs.forEach((img) => (img.style.display = 'none'));
+        display.forEach((img) => {
+          grid.appendChild(img);
+          img.style.display = '';
+          applySize(img, pickKind());
         });
       })();
     </script>


### PR DESCRIPTION
What changed:
- Desktop mosaic is now free-form (uses grid-auto-rows instead of a fixed 2-row template)
- JS assigns randomized tile sizes for a more "chaotic" look (wide/wide2/tall/big)
- Increased tile count (desktop 24, mobile 14)
- If source images are fewer than the target count, we clone a small number to allow repetition

How to verify:
- Open homepage and refresh a few times (layout should look less rigid)
- Ensure no overflow / broken grid on desktop and mobile widths
