### PR TITLE
UI: align Vibe Mosaic bottom edge

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -86,12 +86,12 @@ const BASE_URL = import.meta.env.BASE_URL;
         opacity: 0.92;
       }
 
-      /* Desktop: free-form mosaic (varied sizes, dense packing) */
+      /* Desktop: fixed-height mosaic (varied sizes but flat bottom edge) */
       .footer-gallery__grid {
         display: grid;
         grid-auto-flow: dense;
         grid-template-columns: repeat(12, 1fr);
-        grid-auto-rows: 110px;
+        grid-template-rows: repeat(3, 110px);
         gap: 10px;
         overflow: hidden;
         border-radius: 18px;
@@ -131,7 +131,7 @@ const BASE_URL = import.meta.env.BASE_URL;
       @media (max-width: 900px) {
         .footer-gallery__grid {
           grid-template-columns: repeat(8, 1fr);
-          grid-auto-rows: 100px;
+          grid-template-rows: repeat(3, 100px);
           gap: 9px;
         }
         .footer-gallery__img.is-wide {


### PR DESCRIPTION
Fix:
- Make desktop Vibe Mosaic grid a fixed 3-row height so the bottom edge is flat/aligned
- Keep varied tile sizes (dense packing + spans), but clip overflow to preserve a clean bottom line

How to verify:
- Open homepage on desktop
- Observe the Vibe Mosaic grid bottom edge is straight/aligned (no ragged bottom)
