### PR TITLE
Brand: new futuristic favicon

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,9 +1,42 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 128 128">
-    <path d="M50.4 78.5a75.1 75.1 0 0 0-28.5 6.9l24.2-65.7c.7-2 1.9-3.2 3.4-3.2h29c1.5 0 2.7 1.2 3.4 3.2l24.2 65.7s-11.6-7-28.5-7L67 45.5c-.4-1.7-1.6-2.8-2.9-2.8-1.3 0-2.5 1.1-2.9 2.7L50.4 78.5Zm-1.1 28.2Zm-4.2-20.2c-2 6.6-.6 15.8 4.2 20.2a17.5 17.5 0 0 1 .2-.7 5.5 5.5 0 0 1 5.7-4.5c2.8.1 4.3 1.5 4.7 4.7.2 1.1.2 2.3.2 3.5v.4c0 2.7.7 5.2 2.2 7.4a13 13 0 0 0 5.7 4.9v-.3l-.2-.3c-1.8-5.6-.5-9.5 4.4-12.8l1.5-1a73 73 0 0 0 3.2-2.2 16 16 0 0 0 6.8-11.4c.3-2 .1-4-.6-6l-.8.6-1.6 1a37 37 0 0 1-22.4 2.7c-5-.7-9.7-2-13.2-6.2Z" />
-    <style>
-        path { fill: #000; }
-        @media (prefers-color-scheme: dark) {
-            path { fill: #FFF; }
-        }
-    </style>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <defs>
+    <linearGradient id="g" x1="20" y1="16" x2="108" y2="112" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7cf9ff" />
+      <stop offset="1" stop-color="#8b5cf6" />
+    </linearGradient>
+    <filter id="glow" x="-40%" y="-40%" width="180%" height="180%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="3" result="b" />
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 0.65 0" result="g"/>
+      <feMerge>
+        <feMergeNode in="g" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- Background (fits the site's dark, neon vibe) -->
+  <rect class="bg" x="10" y="10" width="108" height="108" rx="26" />
+
+  <!-- Futuristic monogram mark: J + // + T -->
+  <g filter="url(#glow)" stroke="url(#g)" stroke-width="10" stroke-linecap="round" stroke-linejoin="round">
+    <!-- J -->
+    <path d="M44 32v42c0 10-7 18-18 18" />
+    <!-- // -->
+    <path d="M62 34l-14 60" />
+    <path d="M78 34l-14 60" />
+    <!-- T -->
+    <path d="M86 34h28" />
+    <path d="M100 34v66" />
+  </g>
+
+  <!-- Subtle circuit dot -->
+  <circle cx="96" cy="96" r="4" fill="url(#g)" opacity="0.95" />
+
+  <style>
+    .bg { fill: #05050b; }
+    @media (prefers-color-scheme: light) {
+      .bg { fill: #ffffff; }
+    }
+  </style>
 </svg>


### PR DESCRIPTION
- Replace the default Astro favicon with a custom neon monogram mark
- Matches site palette (cyan + purple) and overall "tech / future" vibe

How to verify:
- Load the site and check the browser tab icon
- Confirm it reads well at small sizes and fits the dark theme
