### PR TITLE
Refactor: homepage top modules cleanup

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,77 +24,40 @@ const pinned = (pinsData?.pins || []).slice(0, 6);
     <div class="hero-content">
       <p class="eyebrow">代码、游戏与臭屁宝</p>
       <h1>
-        你好，我是<span>唐靖凯</span>。
-        <br />写代码、打游戏、带娃。
+        我是<span>唐靖凯</span>。
+        <br />做工程，也做落地。
       </h1>
 
       <img class="avatar" src="/images/avatar.jpg" alt="唐靖凯" loading="eager" decoding="async" fetchpriority="high" />
       <p class="lead">
-        Java 后端工程师（2018 起全职）｜软件工程硕士。
-        关注 AI 大模型应用侧：把新工具落到真实场景；也会记录主机游戏与奶爸日常。
+        Java 后端工程师（2018–），关注 LLM 应用落地与自动化。
+        这里主要写：工程笔记、Agent/AI 实践、主机游戏、以及奶爸日常。
       </p>
+
       <div class="hero-actions">
         <a class="primary" href="/writing">阅读文章</a>
         <a class="ghost" href="/now">最近在干嘛</a>
         <a class="ghost" href="#projects">项目</a>
-      </div>
-      <div class="hero-stats">
-        <div>
-          <strong>Java</strong>
-          <span>后端</span>
-        </div>
-        <div>
-          <strong>AI</strong>
-          <span>应用</span>
-        </div>
-        <div>
-          <strong>奶爸</strong>
-          <span>臭屁宝</span>
-        </div>
       </div>
     </div>
 
     <div class="hero-card">
       <div class="pulse"></div>
       <div class="card-header">
-        <span>身份</span>
-        <span class="status">程序员 / 玩家 / 奶爸</span>
+        <span>快速入口</span>
+        <span class="status">Links</span>
       </div>
-      <h3>Quick Facts</h3>
+      <h3>导航</h3>
       <ul>
-        <li>职业：Java 后端开发（2018–）</li>
-        <li>方向：LLM 应用侧 / 工程落地 / 自动化</li>
-        <li>兴趣：主机游戏</li>
-        <li>家庭：新手奶爸（臭屁宝）</li>
+        <li><a class="signature" href="/writing">Writing →</a></li>
+        <li><a class="signature" href="/now">Now →</a></li>
+        <li><a class="signature" href="/search">Search →</a></li>
+        <li><a class="signature" href="/rss.xml">RSS →</a></li>
+        <li><a class="signature" href="https://github.com/JingkaiTang" target="_blank" rel="noreferrer">GitHub →</a></li>
       </ul>
       <div class="card-footer">
-        <span>订阅</span>
-        <a class="signature" href="/rss.xml">RSS</a>
-      </div>
-    </div>
-  </section>
-
-  <section id="about" class="section glass">
-    <div>
-      <h2>关于</h2>
-      <p>
-        这是一个“生活 + 工作 + 作品集”一体的个人站。
-        我会把工程经验（Java/后端）、AI 应用侧实践、主机游戏体验、以及奶爸日常沉淀在这里。
-        出于隐私考虑：只展示少量公开信息，敏感内容不进仓库、不上网页。
-      </p>
-    </div>
-    <div class="metrics">
-      <div>
-        <h4>代码</h4>
-        <p>Java 后端 / 工程化 / 可复现</p>
-      </div>
-      <div>
-        <h4>AI</h4>
-        <p>大模型应用侧 / Agent / 自动化</p>
-      </div>
-      <div>
-        <h4>生活</h4>
-        <p>主机游戏 / 奶爸（臭屁宝）</p>
+        <span>说明</span>
+        <span>尽量少废话，直接给内容。</span>
       </div>
     </div>
   </section>


### PR DESCRIPTION
Goals
- Make the homepage top area cleaner, less repetitive, and more content-first.

Changes
- Removed the About section (was redundant and wordy)
- Consolidated slogan/intro/business-card content:
  - Hero focuses on a single intro + what the site contains
  - Right card becomes a pure navigation/links panel (no repeated identity/facts)
- Dropped the hero "stats" row to avoid repeating the same labels again

How to verify
- Open homepage: top area should feel simpler and non-repetitive
- Ensure links work: Writing / Now / Search / RSS / GitHub
