### PR TITLE
Simplify homepage hero + add GitHub link

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -223,6 +223,7 @@ const BASE_URL = import.meta.env.BASE_URL;
           <a href="/now">Now</a>
           <a href="/search">Search</a>
           <a href="/rss.xml">RSS</a>
+          <a href="https://github.com/JingkaiTang" target="_blank" rel="noreferrer">GitHub</a>
         </div>
       </nav>
     </header>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -33,33 +33,8 @@ const pinned = (pinsData?.pins || []).slice(0, 6);
         Java 后端工程师（2018–），关注 LLM 应用落地与自动化。
         这里主要写：工程笔记、Agent/AI 实践、主机游戏、以及奶爸日常。
       </p>
-
-      <div class="hero-actions">
-        <a class="primary" href="/writing">阅读文章</a>
-        <a class="ghost" href="/now">最近在干嘛</a>
-        <a class="ghost" href="#projects">项目</a>
-      </div>
     </div>
 
-    <div class="hero-card">
-      <div class="pulse"></div>
-      <div class="card-header">
-        <span>快速入口</span>
-        <span class="status">Links</span>
-      </div>
-      <h3>导航</h3>
-      <ul>
-        <li><a class="signature" href="/writing">Writing →</a></li>
-        <li><a class="signature" href="/now">Now →</a></li>
-        <li><a class="signature" href="/search">Search →</a></li>
-        <li><a class="signature" href="/rss.xml">RSS →</a></li>
-        <li><a class="signature" href="https://github.com/JingkaiTang" target="_blank" rel="noreferrer">GitHub →</a></li>
-      </ul>
-      <div class="card-footer">
-        <span>说明</span>
-        <span>尽量少废话，直接给内容。</span>
-      </div>
-    </div>
   </section>
 
   <section id="latest" class="section">


### PR DESCRIPTION
- 移除首页 Hero 右侧「快速入口」卡片
- 移除 Hero 区域的「阅读文章 / 最近在干嘛 / 项目」三个按钮
- 在右上角导航栏新增 GitHub 主页链接（外链）

验证：本地 `npm run build` 通过；首页 Hero 更简洁，导航栏右侧可直达 GitHub。
