### PR TITLE
Homepage: remove latest note, simplify project homepage label, add nav GitHub

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -223,7 +223,7 @@ const BASE_URL = import.meta.env.BASE_URL;
           <a href="/now">Now</a>
           <a href="/search">Search</a>
           <a href="/rss.xml">RSS</a>
-          <a href="https://github.com/JingkaiTang" target="_blank" rel="noreferrer">GitHub</a>
+          <a href="https://github.com/JingkaiTang" target="_blank" rel="noopener noreferrer">GitHub</a>
         </div>
       </nav>
     </header>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -122,7 +122,7 @@ const pinned = (pinsData?.pins || []).slice(0, 6);
 
           {r.homepageUrl ? (
             <div style="margin-top: 10px;">
-              <a href={r.homepageUrl} target="_blank" rel="noreferrer" aria-label={`${r.name} 项目主页`}>→</a>
+              <a href={r.homepageUrl} target="_blank" rel="noopener noreferrer" aria-label={`${r.name} 项目主页`}>→</a>
             </div>
           ) : null}
         </article>


### PR DESCRIPTION
- 首页「最新」模块：移除右侧说明文案（仅保留标题）
- 首页「项目」模块：去掉卡片内链接文案「项目主页」，仅保留箭头（并补充 aria-label）
- 顶部导航栏（文章/游戏/生活/Now/Search/RSS）新增 GitHub 外链

验证：本地 `npm run build` 通过。
