### PR TITLE
Fix new:post: fail fast in non-interactive exec

### DIFF
--- a/scripts/new-post.mjs
+++ b/scripts/new-post.mjs
@@ -61,7 +61,8 @@ async function main() {
 
   // In non-interactive environments (no TTY), never prompt.
   // This prevents hanging exec sessions (which can get SIGKILL'd by supervisors/timeouts).
-  const interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  const interactive = Boolean(input.isTTY && output.isTTY);
+
   if (!interactive) {
     const missing = [];
     if (!args.title || args.title === 'true') missing.push('--title');
@@ -74,14 +75,14 @@ async function main() {
     }
   }
 
-  const rl = readline.createInterface({ input, output });
+  const rl = interactive ? readline.createInterface({ input, output }) : null;
 
   const title = args.title && args.title !== 'true' ? args.title : await rl.question('Title: ');
   const slugRaw = args.slug && args.slug !== 'true' ? args.slug : await rl.question('Slug (empty = auto): ');
   const tagsRaw = args.tags && args.tags !== 'true' ? args.tags : await rl.question('Tags (comma-separated, optional): ');
   const dateRaw = args.date && args.date !== 'true' ? args.date : await rl.question(`Date (YYYY-MM-DD, default ${todayISO()}): `);
 
-  await rl.close();
+  if (rl) await rl.close();
 
   const pubDate = (dateRaw || '').trim() || todayISO();
   const slug = (slugRaw || '').trim() ? slugify(slugRaw) : slugify(title);


### PR DESCRIPTION
背景：OpenClaw exec 场景下没有 TTY，`npm run new:post` 若缺少参数会进入 readline 交互等待，容易被 supervisor/超时强杀，表现为 SIGKILL。

改动：
- 当检测到非交互环境（stdin/stdout 非 TTY）时：
  - 不再 prompt
  - 强制要求传 `--title` 与 `--slug`
  - 缺参直接 exit(2) 并打印示例命令

验证：
- `npm run build` 通过
- 直接运行 `node scripts/new-post.mjs --date ...` 会 fail fast 并提示需要的参数（不再卡住等待输入）
