### PR TITLE
Feed: lower thumbnail for better text alignment

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -192,6 +192,8 @@ const BASE_URL = import.meta.env.BASE_URL;
         border-radius: 12px;
         border: 1px solid var(--border);
         display: block;
+        /* Nudge down to align visually with text baseline in the right column */
+        margin-top: 6px;
       }
 
       @media (max-width: 560px) {
@@ -204,6 +206,7 @@ const BASE_URL = import.meta.env.BASE_URL;
         .project-card.content-card .content-card__thumb {
           width: 100%;
           height: 180px;
+          margin-top: 0;
         }
       }
     </style>


### PR DESCRIPTION
- Feed 列表卡片：缩略图增加 `margin-top: 6px`，让图片与右侧标题/正文的视觉基线更对齐
- 移动端（缩略图变大图）保持 `margin-top: 0`

验证：`npm run build` 通过。
