### PR TITLE
Nav: reorder links + add AI tag entry

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -221,9 +221,10 @@ const BASE_URL = import.meta.env.BASE_URL;
         <a class="logo" href="/">JINGKAI//TANG</a>
         <div class="nav-links">
           <a href="/writing">文章</a>
-          <a href="/games">游戏</a>
-          <a href="/life">生活</a>
           <a href="/now">Now</a>
+          <a href="/tags/ai/">AI</a>
+          <a href="/tags/game/">游戏</a>
+          <a href="/tags/life/">生活</a>
           <a href="/search">Search</a>
           <a href="/rss.xml">RSS</a>
           <a href="https://github.com/JingkaiTang" target="_blank" rel="noopener noreferrer">GitHub</a>


### PR DESCRIPTION
按需求调整顶部导航栏链接含义与排序：
- 文章 -> /writing（保持）
- Now -> /now（排序提前）
- AI -> /tags/ai/（新增）
- 游戏 -> /tags/game/（从 /games 调整为标签聚合）
- 生活 -> /tags/life/（从 /life 调整为标签聚合）
- Search/RSS/GitHub 保持不变

验证：`npm run build` 通过。
