### PR TITLE
Fix: /tags/game should not 404

### DIFF
--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -20,6 +20,10 @@ export async function getStaticPaths() {
     for (const t of p.data.tags ?? []) tagSet.add(t);
   }
 
+  // Ensure nav-linked tags always have a generated page, even if empty.
+  // (Otherwise /tags/<tag>/ would 404 when there are currently no posts for that tag.)
+  for (const t of ['ai', 'game', 'life']) tagSet.add(t);
+
   return [...tagSet].map((tag) => ({
     params: { tag: encodeURIComponent(tag) },
     props: { tag },


### PR DESCRIPTION
问题：顶部导航新增了「游戏」指向 `/tags/game/`，但当前没有任何内容带 `game` 标签，导致静态路由未生成，从而 404。

修复：在 `src/pages/tags/[tag].astro` 的 `getStaticPaths()` 里强制补齐导航依赖的标签页：`ai/game/life`，即使为空也会生成页面。

验证：`npm run build` 产物中已包含 `/tags/game/index.html`。
