### PR TITLE
Fix: CI requires Node.js 22 for Astro 6

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install


### PR DESCRIPTION
## 问题
PR #91 升级 Astro 到 6.0 后 CI 失败，因为 Astro 6 需要 Node.js >=22.12.0，但 GitHub Actions 仍在使用 Node.js 20。

## 修复
- `.github/workflows/pages.yml`: `node-version: 20` → `node-version: 22`

## 验证
- CI 应该能正常运行 `npm run check` 和 `npm run build`
